### PR TITLE
Improved Resilience when getting multiple tokens at once

### DIFF
--- a/IdentityProxy.Api/Dockerfile
+++ b/IdentityProxy.Api/Dockerfile
@@ -28,7 +28,7 @@ RUN dotnet publish "./IdentityProxy.Api.csproj" -c $BUILD_CONFIGURATION -o /app/
 # Small image
 #FROM mcr.microsoft.com/dotnet/runtime-deps:8.0-jammy-chiseled AS final
 # Small image with AOT (preview)
-FROM mcr.microsoft.com/dotnet/nightly/runtime-deps:8.0-jammy-chiseled-aot as final
+FROM mcr.microsoft.com/dotnet/nightly/runtime-deps:8.0-jammy-chiseled-aot AS final
 
 WORKDIR /app
 EXPOSE 8080

--- a/IdentityProxy.Api/Identity/CertificateStore.cs
+++ b/IdentityProxy.Api/Identity/CertificateStore.cs
@@ -3,15 +3,43 @@ using System.Security.Cryptography.X509Certificates;
 
 namespace IdentityProxy.Api.Identity;
 
+/// <summary>
+/// Register the <see cref="CertificateStore"/> as a singleton, we only want one certificate to sign the tokens
+/// </summary>
 internal class CertificateStore : IDisposable
 {
     private const int VALID_FROM_MINUTES_ADJUSTMENT = -5;
     private const int VALID_UNTIL_DAYS_ADJUSTMENT = 10;
+    private readonly TimeProvider _timeProvider;
     private readonly SemaphoreSlim semaphore = new(1, 1);
     private X509Certificate2? certificate;
 
+    /// <summary>
+    /// Certificate Store to generate a certificate to sign the tokens
+    /// </summary>
+    /// <param name="timeProvider"></param>
+    public CertificateStore(TimeProvider timeProvider)
+    {
+        _timeProvider = timeProvider;
+    }
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        if (certificate != null)
+        {
+            certificate.Dispose();
+        }
+    }
+
+    /// <summary>
+    /// Get the certificate to sign the tokens
+    /// </summary>
+    /// <remarks>By design the certificate is not stored anywhere, this 'IdentityProxy' is meant to fake tokens during integration tests. And is by no means to ever be exposed to the internet!</remarks>
     public X509Certificate2 GetX509Certificate2()
     {
+        // Double-checked locking
+        // We only want to generate the certificate once
         if (certificate == null)
         {
             semaphore.Wait();
@@ -19,19 +47,20 @@ internal class CertificateStore : IDisposable
             {
                 if (certificate == null)
                 {
-                    certificate = GenerateCertificate("TokenProxySingingCert");
+                    certificate = GenerateCertificate("TokenProxySingingCert", _timeProvider.GetUtcNow());
                 }
             }
             finally
             {
+                // Always release the semaphore, to avoid deadlocks
                 semaphore.Release();
             }
         }
-
-        return certificate;
+        // Return a copy of the certificate, since the certificate is not thread-safe and we don't want to dispose the certificate
+        return new X509Certificate2(certificate);
     }
 
-    private static X509Certificate2 GenerateCertificate(string subjectCn, int keySize = 2048)
+    private static X509Certificate2 GenerateCertificate(string subjectCn, DateTimeOffset now, int keySize = 2048)
     {
         using var rsa = RSA.Create(keySize); // Generate a new RSA key pair
 
@@ -44,21 +73,13 @@ internal class CertificateStore : IDisposable
         request.CertificateExtensions.Add(new X509BasicConstraintsExtension(true, false, 0, true));
 
         // Set the validity period
-        var notBefore = DateTimeOffset.Now.AddMinutes(VALID_FROM_MINUTES_ADJUSTMENT);
-        var notAfter = DateTimeOffset.Now.AddMinutes(VALID_UNTIL_DAYS_ADJUSTMENT);
+        var notBefore = now.AddMinutes(VALID_FROM_MINUTES_ADJUSTMENT);
+        var notAfter = now.AddDays(VALID_UNTIL_DAYS_ADJUSTMENT);
 
         // Create the certificate
         var cert = request.CreateSelfSigned(notBefore, notAfter);
 
         // Export the certificate with the private key, then re-import it to generate an X509Certificate2 object
         return new X509Certificate2(cert.Export(X509ContentType.Pfx), "", X509KeyStorageFlags.Exportable);
-    }
-
-    public void Dispose()
-    {
-        if (certificate != null)
-        {
-            certificate.Dispose();
-        }
     }
 }

--- a/IdentityProxy.Api/Identity/IdentityEndpoints.cs
+++ b/IdentityProxy.Api/Identity/IdentityEndpoints.cs
@@ -6,6 +6,15 @@ internal static class IdentityEndpoints
 {
     public static void MapIdentityEndpoints(this WebApplication app, string? externalUrl = null, string openIdConfigUrl = "/.well-known/openid-configuration", string identityPrefix = "/api/identity")
     {
+        app.MapGet("/", async (IConfiguration configuration, CancellationToken cancellationToken) =>
+        {
+            return Results.Ok(new IdentityProxyDescription
+            {
+                Authority = configuration.GetValue<string>("IDENTITY_AUTHORITY") ?? "Configure 'IDENTITY_AUTHORITY' in Environment!",
+                ExternalUrl = externalUrl ?? configuration.GetValue<string>("EXTERNAL_URL") ?? "Configure 'EXTERNAL_URL' in environment"
+            });
+        });
+
         // Add the well known config endpoint /.well-known/openid-configuration
         // The IdentityService is injected
         app.MapGet(openIdConfigUrl, async (IdentityService identityService, IConfiguration configuration, CancellationToken cancellationToken) =>

--- a/IdentityProxy.Api/Identity/Models/IdentityJsonSerializerContext.cs
+++ b/IdentityProxy.Api/Identity/Models/IdentityJsonSerializerContext.cs
@@ -7,6 +7,7 @@ namespace IdentityProxy.Api.Identity.Models;
 [JsonSerializable(typeof(Jwks))]
 [JsonSerializable(typeof(TokenRequest))]
 [JsonSerializable(typeof(TokenResponse))]
+[JsonSerializable(typeof(IdentityProxyDescription))]
 internal partial class IdentityJsonSerializerContext : JsonSerializerContext
 {
 

--- a/IdentityProxy.Api/Identity/Models/IdentityProxyDescription.cs
+++ b/IdentityProxy.Api/Identity/Models/IdentityProxyDescription.cs
@@ -1,0 +1,13 @@
+﻿namespace IdentityProxy.Api.Identity.Models;
+
+public class IdentityProxyDescription
+{
+    public string Application { get; set; } = "IdentityProxy";
+    public string Repository { get; set; } = "https://github.com/svrooij/identityproxy";
+    public string Version => GetType().Assembly.GetName().Version?.ToString() ?? "0.0.0";
+    public required string Authority { get; set; }
+    public required string ExternalUrl { get; set; }
+    public string OpenIdConfigUrl => $"{ExternalUrl}/.well-known/openid-configuration";
+    public string JwksUrl => $"{ExternalUrl}/api/identity/jwks";
+    public string TokenUrl => $"{ExternalUrl}/api/identity/token";
+}

--- a/IdentityProxy.Api/Program.cs
+++ b/IdentityProxy.Api/Program.cs
@@ -7,6 +7,7 @@ var builder = WebApplication.CreateSlimBuilder(args);
 // Register some services
 builder.Services.AddMemoryCache();
 builder.Services.AddSingleton<CertificateStore>();
+builder.Services.AddSingleton(TimeProvider.System);
 
 var authority = builder.Configuration.GetValue<string>("IDENTITY_AUTHORITY") ?? throw new AppConfigurationException("IDENTITY_AUTHORITY is not set");
 builder.Services.AddSingleton(new IdentityServiceSettings { Authority = authority });

--- a/IdentityProxy.Api/appsettings.Development.json
+++ b/IdentityProxy.Api/appsettings.Development.json
@@ -2,7 +2,8 @@
   "Logging": {
     "LogLevel": {
       "Default": "Information",
-      "Microsoft.AspNetCore": "Warning"
+      "Microsoft.AspNetCore": "Warning",
+      "Microsoft.Hosting.Lifetime": "Information"
     }
   }
 }

--- a/IdentityProxy.Test/AsyncExtensions.cs
+++ b/IdentityProxy.Test/AsyncExtensions.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace IdentityProxy.Test;
+
+public static class AsyncExtensions
+{
+    public static async IAsyncEnumerable<T> ExecuteAsync<T>(this IEnumerable<Task<T>> tasks)
+    {
+        foreach (var task in tasks)
+        {
+            yield return await task;
+        }
+    }
+}

--- a/IdentityProxy.Test/AsyncExtensions.cs
+++ b/IdentityProxy.Test/AsyncExtensions.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace IdentityProxy.Test;
+﻿namespace IdentityProxy.Test;
 
 public static class AsyncExtensions
 {

--- a/IdentityProxy.Test/Program.cs
+++ b/IdentityProxy.Test/Program.cs
@@ -1,7 +1,7 @@
 ﻿// See https://aka.ms/new-console-template for more information
 
 // This is how you would use the Testcontainers.IdentityProxy library
-
+using IdentityProxy.Test;
 using Testcontainers.IdentityProxy;
 
 var identityProxy = new IdentityProxyBuilder()
@@ -10,22 +10,61 @@ var identityProxy = new IdentityProxyBuilder()
 
 await identityProxy.StartAsync();
 var authority = identityProxy.GetAuthority();
+
 Console.WriteLine($"Well known config at: {authority}.well-known/openid-configuration");
 Console.WriteLine($"JWKS_uri at: {authority}api/identity/jwks");
 
 Console.WriteLine($"You can request a token by posting to {authority}api/identity/token");
-// Or by using identityProxy.GetTokenAsync(...)
-var tokenResult = await identityProxy.GetTokenAsync(new TokenRequest
-{
-    Audience = "https://api.svrooij.io",
-    Subject = "test",
-    AdditionalClaims = new Dictionary<string, object>
-    {
-        { "scope", "openid profile email" }
-    }
-});
+Console.WriteLine("Sample token request:");
+Console.WriteLine();
+Console.Write($@"POST {authority}api/identity/token
+Accept: application/json
+Content-Type: application/json
 
-Console.WriteLine($"Token: {tokenResult?.AccessToken}");
+{{
+  ""aud"": ""62eb2412-f410-4e23-95e7-6a91146bc32c"",
+  ""sub"": ""99f0cbaa-b3bb-4a77-81a5-e8d17b2232ec""
+}}");
+
+Console.WriteLine();
+Console.WriteLine();
+
+var token = await identityProxy.GetTokenAsync(new TokenRequest
+{
+    Audience = "62eb2412-f410-4e23-95e7-6a91146bc32c",
+    Subject = "99f0cbaa-b3bb-4a77-81a5-e8d17b2232ec"
+});
+Console.WriteLine("Sample token response:");
+Console.WriteLine();
+Console.Write($@"{{
+  ""access_token"": ""{token?.AccessToken}"",
+  ""expires_in"": {token?.ExpiresIn},
+}}");
+
+
+//// Get 100 tokens (to test if the proxy can handle multiple requests, as it should in test cases)
+//var tasks = new List<Task<TokenResult?>>();
+//for (int i = 0; i < 100; i++)
+//{
+//    tasks.Add(identityProxy.GetTokenAsync(new TokenRequest
+//    {
+//        Audience = "https://api.svrooij.io",
+//        Subject = "test",
+//        AdditionalClaims = new Dictionary<string, object>
+//        {
+//            { "scope", "openid profile email" },
+//            { "jti", Guid.NewGuid().ToString() }
+//        },
+//    }));
+//}
+
+//int mycounter = 0;
+//await foreach (var task in tasks.ExecuteAsync())
+//{
+//    //Console.WriteLine($"Token {mycounter++}");
+//    Console.WriteLine(task?.AccessToken);
+//}
+
 
 Console.ReadLine();
 

--- a/SvRooij.Testcontainers.IdentityProxy/IdentityProxyBuilder.cs
+++ b/SvRooij.Testcontainers.IdentityProxy/IdentityProxyBuilder.cs
@@ -10,12 +10,15 @@ namespace Testcontainers.IdentityProxy;
 /// Builder for the <see cref="IdentityProxyContainer"/>
 /// </summary>
 /// <remarks>
-/// Call <see cref="WithAuthority(string)"/> to set the current authority, this will be mocked. Be sure to also call <see cref="WithPort(int)"/> or <see cref="WithRandomPort"/> to set the port and the "EXTERNAL_URL".
+/// Call <see cref="WithAuthority(string)"/> to set the current authority, this will be mocked.
 /// </remarks>
 public class IdentityProxyBuilder : ContainerBuilder<IdentityProxyBuilder, IdentityProxyContainer, IdentityProxyConfiguration>
 {
     private const string IDENTITY_PROXY_IMAGE = "ghcr.io/svrooij/identityproxy:latest";
 
+    /// <summary>
+    /// The internal port of the identity proxy
+    /// </summary>
     public const ushort API_PORT = 8080;
 
     /// <summary>
@@ -26,11 +29,12 @@ public class IdentityProxyBuilder : ContainerBuilder<IdentityProxyBuilder, Ident
         DockerResourceConfiguration = Init().DockerResourceConfiguration;
     }
 
-    public IdentityProxyBuilder(IdentityProxyConfiguration dockerResourceConfiguration) : base(dockerResourceConfiguration)
+    internal IdentityProxyBuilder(IdentityProxyConfiguration dockerResourceConfiguration) : base(dockerResourceConfiguration)
     {
         DockerResourceConfiguration = dockerResourceConfiguration;
     }
 
+    /// <inheritdoc/>
     protected override IdentityProxyConfiguration DockerResourceConfiguration { get; }
 
     /// <summary>
@@ -47,22 +51,26 @@ public class IdentityProxyBuilder : ContainerBuilder<IdentityProxyBuilder, Ident
             .WithEnvironment("IDENTITY_AUTHORITY", authority);
     }
 
+    /// <inheritdoc/>
     public override IdentityProxyContainer Build()
     {
         Validate();
         return new IdentityProxyContainer(DockerResourceConfiguration);
     }
 
+    /// <inheritdoc/>
     protected override IdentityProxyBuilder Clone(IContainerConfiguration resourceConfiguration)
     {
         return Merge(DockerResourceConfiguration, new IdentityProxyConfiguration(resourceConfiguration));
     }
 
+    /// <inheritdoc/>
     protected override IdentityProxyBuilder Clone(IResourceConfiguration<CreateContainerParameters> resourceConfiguration)
     {
         return Merge(DockerResourceConfiguration, new IdentityProxyConfiguration(resourceConfiguration));
     }
 
+    /// <inheritdoc/>
     protected override IdentityProxyBuilder Init()
     {
         return base.Init()
@@ -82,11 +90,13 @@ public class IdentityProxyBuilder : ContainerBuilder<IdentityProxyBuilder, Ident
             });
     }
 
+    /// <inheritdoc/>
     protected override IdentityProxyBuilder Merge(IdentityProxyConfiguration oldValue, IdentityProxyConfiguration newValue)
     {
         return new IdentityProxyBuilder(new IdentityProxyConfiguration(oldValue, newValue));
     }
 
+    /// <inheritdoc/>
     protected override void Validate()
     {
         base.Validate();

--- a/SvRooij.Testcontainers.IdentityProxy/IdentityProxyBuilder.cs
+++ b/SvRooij.Testcontainers.IdentityProxy/IdentityProxyBuilder.cs
@@ -14,7 +14,11 @@ namespace Testcontainers.IdentityProxy;
 /// </remarks>
 public class IdentityProxyBuilder : ContainerBuilder<IdentityProxyBuilder, IdentityProxyContainer, IdentityProxyConfiguration>
 {
-    private const string IDENTITY_PROXY_IMAGE = "ghcr.io/svrooij/identityproxy:latest";
+    /// <summary>
+    /// The default image for the identity proxy
+    /// </summary>
+    /// <remarks>Source has 'latest', in the nuget package this is replaced with the actual version</remarks>
+    public const string IDENTITY_PROXY_IMAGE = "ghcr.io/svrooij/identityproxy:latest";
 
     /// <summary>
     /// The internal port of the identity proxy

--- a/SvRooij.Testcontainers.IdentityProxy/IdentityProxySettings.cs
+++ b/SvRooij.Testcontainers.IdentityProxy/IdentityProxySettings.cs
@@ -8,26 +8,39 @@ namespace Testcontainers.IdentityProxy;
 /// </summary>
 public sealed class IdentityProxyConfiguration : ContainerConfiguration
 {
+    /// <summary>
+    /// <see cref="IdentityProxyConfiguration"/> constructor with just an authority
+    /// </summary>
+    /// <param name="authority"></param>
     public IdentityProxyConfiguration(string? authority = null)
     {
         Authority = authority;
     }
 
-    public IdentityProxyConfiguration(IResourceConfiguration<CreateContainerParameters> resourceConfiguration) : base(resourceConfiguration)
+    /// <summary>
+    /// <see cref="IdentityProxyConfiguration"/> constructor with a <see cref="IResourceConfiguration{TResource}"/>
+    /// </summary>
+    /// <param name="resourceConfiguration">Resource configuration</param>
+    internal IdentityProxyConfiguration(IResourceConfiguration<CreateContainerParameters> resourceConfiguration) : base(resourceConfiguration)
     {
     }
 
-    public IdentityProxyConfiguration(IContainerConfiguration resourceConfiguration)
-        : base(resourceConfiguration)
+    /// <summary>
+    /// <see cref="IdentityProxyConfiguration"/> constructor with a <see cref="IContainerConfiguration"/>
+    /// </summary>
+    /// <param name="containerConfiguration">Container configuration</param>
+    internal IdentityProxyConfiguration(IContainerConfiguration containerConfiguration)
+        : base(containerConfiguration)
     {
         // Passes the configuration upwards to the base implementations to create an updated immutable copy.
     }
 
-    public IdentityProxyConfiguration(IdentityProxyConfiguration resourceConfiguration) : this(new IdentityProxyConfiguration(), resourceConfiguration)
-    {
-    }
-
-    public IdentityProxyConfiguration(IdentityProxyConfiguration oldValue, IdentityProxyConfiguration newValue) : base(oldValue, newValue)
+    /// <summary>
+    /// Merge two <see cref="IdentityProxyConfiguration"/> instances
+    /// </summary>
+    /// <param name="oldValue">Previous value</param>
+    /// <param name="newValue">New properties to merge</param>
+    internal IdentityProxyConfiguration(IdentityProxyConfiguration oldValue, IdentityProxyConfiguration newValue) : base(oldValue, newValue)
     {
         Authority = BuildConfiguration.Combine(oldValue.Authority, newValue.Authority);
     }

--- a/SvRooij.Testcontainers.IdentityProxy/SvRooij.Testcontainers.IdentityProxy.csproj
+++ b/SvRooij.Testcontainers.IdentityProxy/SvRooij.Testcontainers.IdentityProxy.csproj
@@ -17,6 +17,7 @@
     <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
     <IncludeSymbols>False</IncludeSymbols>
     <EnforceCodeStyleInBuild>True</EnforceCodeStyleInBuild>
+    <GenerateDocumentationFile>True</GenerateDocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Since this is probably going to be called from a multiple tests at once, we definitely need to make it as stable as possible.

- Retry to get tokens
- Force creation of a single certificate