### PR TITLE
Enable openapi specs on the project and re-enable net8.0

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -93,7 +93,9 @@ jobs:
     - name: 👨‍🔧 Setup .NET Core SDK
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 10.x
+        dotnet-version: |
+          10.x
+          8.x
 
     - name: 🔍 Enable problem matchers
       run: echo "::add-matcher::.github/matchers/dotnet.json"

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Content-Type: application/json
 The `sub` (Subject) claim is required, everything else is optional.
 Microsoft Entra also uses the `aud` (Audience) claim.
 Any additional claims you provide will be added to the token.
-The `nbf` (Not Before) and `exp` (Expiration) claims are automatically added to the token, you can however control the lifetime of the token by providing the `expires_in` parameter, with the number of seconds you want to token to be valid.
+The `nbf` (Not Before) and `exp` (Expiration) claims are automatically added to the token, you can however control the lifetime of the token by providing the `expires_in` parameter, with the number of seconds you want the token to be valid.
 
 And you'll get a response like this:
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ docker run -p 8080:8080 -e EXTERNAL_URL='http://localhost:8080/' -e IDENTITY_AUT
 
 The `EXTERNAL_URL` is the URL where the proxy is reachable from the outside. The `IDENTITY_AUTHORITY` is the base URL of the IdP to mock. The proxy will then listen on port 8080 and forward requests to the IdP.
 
+You can also check out the interactive documentation at `http://localhost:8080/scalar/` or the openapi spec at `http://localhost:8080/openapi/v1.json`
+
 ### Get a mocked token
 
 If you want a token you can request it from the `/api/identity/token` endpoint. The token will be signed with a certificate that is generated on startup. This certificate (the public key) is also injected in the JWKS response (so the server will accept the tokens as if they were real).
@@ -73,7 +75,7 @@ Content-Type: application/json
 ```
 
 The `sub` (Subject) claim is required, everything else is optional.
-Microsoft Entra also uses the `aud` (Audience) claim, so this is always set in the token.
+Microsoft Entra also uses the `aud` (Audience) claim.
 Any additional claims you provide will be added to the token.
 The `nbf` (Not Before) and `exp` (Expiration) claims are automatically added to the token, you can however control the lifetime of the token by providing the `expires_in` parameter, with the number of seconds you want to token to be valid.
 
@@ -171,6 +173,4 @@ sequenceDiagram
 
 I've tried my best to make the proxy as fast as possible, by enabling [Native AOT](https://learn.microsoft.com/aspnet/core/fundamentals/native-aot?view=aspnetcore-8.0&wt.mc_id=SEC-MVP-5004985) and packaging it in a [chiseled](https://devblogs.microsoft.com/dotnet/announcing-dotnet-chiseled-containers/) docker image.
 
-Having an OpenAPI spec would be nice, but is seems there is an issue with [Swashbuckle and AOT](https://github.com/domaindrivendev/Swashbuckle.AspNetCore/commit/61d890c8dcefe292c8c4582670d24c8f6bf90ce7).
-
-And the root url should return a fancy page with some info about the proxy, if someone would actually open it in their browser.
+As of version `v0.3.3` there is an interactive documentation page running at the `/scalar` endpoint, which uses the OpenAPI specifications available at `/openapi/v1.json`.

--- a/global.json
+++ b/global.json
@@ -1,0 +1,5 @@
+{
+  "test": {
+    "runner": "Microsoft.Testing.Platform"
+  }
+}

--- a/src/IdentityProxy.Api/Dockerfile
+++ b/src/IdentityProxy.Api/Dockerfile
@@ -30,7 +30,7 @@ RUN dotnet publish "./IdentityProxy.Api.csproj" -c $BUILD_CONFIGURATION -o /app/
 # Small image
 #FROM mcr.microsoft.com/dotnet/runtime-deps:8.0-jammy-chiseled AS final
 # Small image with AOT (preview)
-FROM mcr.microsoft.com/dotnet/nightly/runtime-deps:8.0-jammy-chiseled-aot AS final
+FROM mcr.microsoft.com/dotnet/runtime-deps:10.0-noble-chiseled AS final
 
 WORKDIR /app
 EXPOSE 8080

--- a/src/IdentityProxy.Api/Identity/CertificateStore.cs
+++ b/src/IdentityProxy.Api/Identity/CertificateStore.cs
@@ -80,6 +80,6 @@ internal class CertificateStore : IDisposable
         var cert = request.CreateSelfSigned(notBefore, notAfter);
 
         // Export the certificate with the private key, then re-import it to generate an X509Certificate2 object
-        return new X509Certificate2(cert.Export(X509ContentType.Pfx), "", X509KeyStorageFlags.Exportable);
+        return X509CertificateLoader.LoadPkcs12(cert.Export(X509ContentType.Pfx), "", X509KeyStorageFlags.Exportable);
     }
 }

--- a/src/IdentityProxy.Api/Identity/IdentityEndpoints.cs
+++ b/src/IdentityProxy.Api/Identity/IdentityEndpoints.cs
@@ -14,11 +14,19 @@ internal static class IdentityEndpoints
                 Authority = configuration.GetValue<string>("IDENTITY_AUTHORITY") ?? "Configure 'IDENTITY_AUTHORITY' in Environment!",
                 ExternalUrl = externalUrl ?? configuration.GetValue<string>("EXTERNAL_URL") ?? "Configure 'EXTERNAL_URL' in environment"
             });
-        });
+        })
+            .WithName("GetProxyConfig")
+            .WithTags("IdentityProxy")
+            .AddOpenApiOperationTransformer((operation, _, _) =>
+            {
+                operation.Summary = "Get config";
+                operation.Description = "Get basic information about the identity proxy, or use to check if running.";
+                return Task.CompletedTask;
+            }).Produces<IdentityProxyDescription>(200);
 
         // Add the well known config endpoint /.well-known/openid-configuration
         // The IdentityService is injected
-        app.MapGet(openIdConfigUrl, async (IdentityService identityService, IConfiguration configuration, CancellationToken cancellationToken) =>
+        app.MapGet(openIdConfigUrl, async ([FromServices] IdentityService identityService, [FromServices] IConfiguration configuration, CancellationToken cancellationToken) =>
         {
             // We need to clone the configuration because we need to change the jwks uri and we don't want to change the original.
             var config = (await identityService.GetExternalOpenIdConfigurationAsync(cancellationToken))!.Clone() as OpenIdConfiguration;
@@ -29,30 +37,57 @@ internal static class IdentityEndpoints
                 config!.JwksUri = new Uri(new Uri(externalUrl), $"{identityPrefix}/jwks").ToString();
             }
             return Results.Ok(config);
-        });
+        })
+            .WithName("GetOpenIDConnectConfiguration")
+            .WithTags("OpenID Connect")
+            .AddOpenApiOperationTransformer((operation, _, _) =>
+        {
+            operation.Summary = "openid-configuration";
+            operation.Description = "Modified OpenID configuration";
+            return Task.CompletedTask;
+        })
+        .Produces<OpenIdConfiguration>(200);
 
         // Group all Identity endpoints under the identityPrefix
         var identityApi = app.MapGroup(identityPrefix);
 
         // Add the jwks endpoint {identityPrefix}/jwks
         // The IdentityService is injected
-        identityApi.MapGet("/jwks", async (IdentityService identityService, CancellationToken cancellationToken) =>
+        identityApi.MapGet("/jwks", async ([FromServices] IdentityService identityService, CancellationToken cancellationToken) =>
         {
             var jwks = await identityService.GetJwksWithExtraSigningCertAsync(cancellationToken);
             return Results.Ok(jwks);
-        });
+        })
+            .WithName("GetAllSigningKeys")
+            .WithTags("OpenID Connect")
+            .AddOpenApiOperationTransformer((operation, _, _) =>
+        {
+            operation.Summary = "jwks";
+            operation.Description = "Modified JWKS response, copy from IDP with extra cert";
+            return Task.CompletedTask;
+        })
+        .Produces<Jwks>(200);
 
         // Add the token endpoint {identityPrefix}/token
         // The IdentityService is injected and the TokenRequest is bound from the request body
-        identityApi.MapPost("/token", async (IdentityService identityService, [FromBody] TokenRequest request, CancellationToken cancellationToken) =>
+        identityApi.MapPost("/token", async ([FromBody] TokenRequest request, [FromServices] IdentityService identityService, CancellationToken cancellationToken) =>
         {
             var token = await identityService.GetTokenAsync(request, cancellationToken);
             return Results.Ok(token);
-        });
+        })
+            .WithName("GetToken")
+            .WithTags("Tokens")
+            .AddOpenApiOperationTransformer((operation, _, _) =>
+            {
+                operation.Summary = "Get token";
+                operation.Description = "Get a token signed with the extra signing certificate";
+                return Task.CompletedTask;
+            })
+            .Produces<TokenResponse>(200);
 
         // Add the token endpoint {identityPrefix}/duplicate-token
         // The IdentityService is injected and the token to duplicate is bound from the request body
-        identityApi.MapPost("/duplicate-token", async (IdentityService identityService, [FromBody] DuplicateTokenRequest tokenRequest, CancellationToken cancellationToken) =>
+        identityApi.MapPost("/duplicate-token", async ([FromBody] DuplicateTokenRequest tokenRequest, [FromServices] IdentityService identityService, CancellationToken cancellationToken) =>
         {
             var newToken = await identityService.GetTokenAsync(tokenRequest.Token, cancellationToken);
             if (newToken is null)
@@ -60,6 +95,15 @@ internal static class IdentityEndpoints
                 return Results.BadRequest(new { error = "invalid_token", error_description = "The provided token is invalid or could not be duplicated." });
             }
             return Results.Ok(newToken);
-        });
+        })
+            .WithName("CloneToken")
+            .WithTags("Tokens")
+            .AddOpenApiOperationTransformer((operation, _, _) =>
+            {
+                operation.Summary = "Clone token";
+                operation.Description = "Get a token signed with the extra signing certificate";
+                return Task.CompletedTask;
+            })
+            .Produces<TokenResponse>(200);
     }
 }

--- a/src/IdentityProxy.Api/Identity/IdentityEndpoints.cs
+++ b/src/IdentityProxy.Api/Identity/IdentityEndpoints.cs
@@ -101,7 +101,7 @@ internal static class IdentityEndpoints
             .AddOpenApiOperationTransformer((operation, _, _) =>
             {
                 operation.Summary = "Clone token";
-                operation.Description = "Get a token signed with the extra signing certificate";
+                operation.Description = "Duplicate an existing JWT token and re-sign it with the extra signing certificate";
                 return Task.CompletedTask;
             })
             .Produces<TokenResponse>(200);

--- a/src/IdentityProxy.Api/Identity/Models/IdentityProxyDescription.cs
+++ b/src/IdentityProxy.Api/Identity/Models/IdentityProxyDescription.cs
@@ -10,4 +10,5 @@ public class IdentityProxyDescription
     public string OpenIdConfigUrl => $"{ExternalUrl}/.well-known/openid-configuration";
     public string JwksUrl => $"{ExternalUrl}/api/identity/jwks";
     public string TokenUrl => $"{ExternalUrl}/api/identity/token";
+    public string DocumentationUrl => $"{ExternalUrl}/scalar/";
 }

--- a/src/IdentityProxy.Api/IdentityProxy.Api.csproj
+++ b/src/IdentityProxy.Api/IdentityProxy.Api.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
@@ -12,7 +12,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-	<PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.14.0" />
+	<PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.0" />
+	<PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.15.0" />
+	<PackageReference Include="Scalar.AspNetCore" Version="2.11.0" />
   </ItemGroup>
 
 </Project>

--- a/src/IdentityProxy.Api/Program.cs
+++ b/src/IdentityProxy.Api/Program.cs
@@ -1,6 +1,7 @@
 using IdentityProxy.Api;
 using IdentityProxy.Api.Identity;
 using IdentityProxy.Api.Identity.Models;
+using Scalar.AspNetCore;
 
 var builder = WebApplication.CreateSlimBuilder(args);
 
@@ -8,6 +9,7 @@ var builder = WebApplication.CreateSlimBuilder(args);
 builder.Services.AddMemoryCache();
 builder.Services.AddSingleton<CertificateStore>();
 builder.Services.AddSingleton(TimeProvider.System);
+builder.Services.AddOpenApi();
 
 var authority = builder.Configuration.GetValue<string>("IDENTITY_AUTHORITY") ?? throw new AppConfigurationException("IDENTITY_AUTHORITY is not set");
 builder.Services.AddSingleton(new IdentityServiceSettings { Authority = authority });
@@ -23,5 +25,14 @@ builder.Services.ConfigureHttpJsonOptions(options =>
 var app = builder.Build();
 // Add the identity endpoints
 app.MapIdentityEndpoints(externalUrl: app.Configuration.GetValue<string>("EXTERNAL_URL"));
+app.MapOpenApi();
+app.MapScalarApiReference(options =>
+{
+    options.Title = "Identity Proxy API";
+    options.HideClientButton = true;
+    options.DarkMode = true;
+    options.DynamicBaseServerUrl = true;
+});
+
 app.Logger.LogInformation("IdentityProxy will proxy authority: {Authority}", authority);
 await app.RunAsync();

--- a/src/SvRooij.Testcontainers.IdentityProxy/IdentityProxyBuilder.cs
+++ b/src/SvRooij.Testcontainers.IdentityProxy/IdentityProxyBuilder.cs
@@ -62,6 +62,20 @@ public class IdentityProxyBuilder : ContainerBuilder<IdentityProxyBuilder, Ident
         return new IdentityProxyContainer(DockerResourceConfiguration);
     }
 
+    /// <summary>
+    /// Builds and returns an instance of <see cref="IdentityProxyContainer"/> using the specified <see
+    /// cref="HttpClient"/>.
+    /// </summary>
+    /// <param name="httpClient">The <see cref="HttpClient"/> instance to be used by the <see cref="IdentityProxyContainer"/>. Cannot be <see
+    /// langword="null"/>.</param>
+    /// <returns>A new instance of <see cref="IdentityProxyContainer"/> configured with the current settings and the specified
+    /// <see cref="HttpClient"/>.</returns>
+    public IdentityProxyContainer Build(HttpClient httpClient)
+    {
+        Validate();
+        return new IdentityProxyContainer(DockerResourceConfiguration, httpClient);
+    }
+
     /// <inheritdoc/>
     protected override IdentityProxyBuilder Clone(IContainerConfiguration resourceConfiguration)
     {

--- a/src/SvRooij.Testcontainers.IdentityProxy/IdentityProxyContainer.cs
+++ b/src/SvRooij.Testcontainers.IdentityProxy/IdentityProxyContainer.cs
@@ -13,10 +13,10 @@ public class IdentityProxyContainer : DockerContainer
 {
     private readonly HttpClient _httpClient;
     private int? _port;
-    internal IdentityProxyContainer(IdentityProxyConfiguration configuration) : base(configuration)
+    internal IdentityProxyContainer(IdentityProxyConfiguration configuration, HttpClient? httpClient = null) : base(configuration)
     {
         // Create a http client to communicate with the auth proxy and get mocked tokens
-        _httpClient = new HttpClient();
+        _httpClient = httpClient ?? new HttpClient();
     }
 
     /// <summary>

--- a/src/SvRooij.Testcontainers.IdentityProxy/SvRooij.Testcontainers.IdentityProxy.csproj
+++ b/src/SvRooij.Testcontainers.IdentityProxy/SvRooij.Testcontainers.IdentityProxy.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
 	<DefaultNamespace>Testcontainers.IdentityProxy</DefaultNamespace>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFrameworks>net10.0;net8.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <RootNamespace>$(MSBuildProjectName.Replace(" ", "_").Replace("SvRooij.","")</RootNamespace>

--- a/tests/SvRooij.Testcontainers.IdentityProxy.Tests/IdentityProxyEndpointsTests.cs
+++ b/tests/SvRooij.Testcontainers.IdentityProxy.Tests/IdentityProxyEndpointsTests.cs
@@ -21,7 +21,7 @@ public class IdentityProxyEndpointsTests
                 .WithAuthority("https://login.microsoftonline.com/svrooij.io/v2.0/");
             _container = builder.Build();
         }
-        await _container.StartAsync(TestContext.Current?.CancellationToken ?? CancellationToken.None);
+        await _container.StartAsync(TestContext.Current?.Execution.CancellationToken ?? CancellationToken.None);
     }
 
     [Test]
@@ -53,7 +53,7 @@ public class IdentityProxyEndpointsTests
             AdditionalClaims = new()
         };
         tokenRequest.AdditionalClaims.Add("some_claim", "with a value");
-        var token = await _container!.GetTokenAsync(tokenRequest, TestContext.Current?.CancellationToken ?? CancellationToken.None);
+        var token = await _container!.GetTokenAsync(tokenRequest, TestContext.Current?.Execution.CancellationToken ?? CancellationToken.None);
         await Assert.That(token).IsNotNull();
         await Assert.That(token.AccessToken).IsNotNull();
         await Assert.That(token.ExpiresIn).IsGreaterThan(0);
@@ -68,7 +68,7 @@ public class IdentityProxyEndpointsTests
     [Arguments("eyJhbGciOiJSUzI1NiIsImtpZCI6InhsVXBic3RoWmZHX04wUGRzYTRsbW10bU53bF91YlUxWXRtVHVjd1pOSkkiLCJ0eXAiOiJKV1QifQ.eyJhdWQiOiI2MmViMjQxMi1mNDEwLTRlMjMtOTVlNy02YTkxMTQ2YmMzMmMiLCJpc3MiOiJodHRwczovL2xvZ2luLm1pY3Jvc29mdG9ubGluZS5jb20vZGY2OGFhMDMtNDhlYi00YjA5LTlmM2UtOGFlY2M1OGUyMDdjL3YyLjAiLCJleHAiOjE3NjA0NzU1ODAsImlhdCI6MTc2MDQ3MTk4MCwibmJmIjoxNzYwNDcxOTcwLCJzdWIiOiI5OWYwY2JhYS1iM2JiLTRhNzctODFhNS1lOGQxN2IyMjMyZWMifQ")]
     public async Task IdentityProxy_should_duplicate_token(string inputToken)
     {
-        var token = await _container!.DuplicateTokenAsync(inputToken, TestContext.Current?.CancellationToken ?? CancellationToken.None);
+        var token = await _container!.DuplicateTokenAsync(inputToken, TestContext.Current?.Execution.CancellationToken ?? CancellationToken.None);
         await Assert.That(token).IsNotNull();
         await Assert.That(token.AccessToken).IsNotNull();
     }

--- a/tests/SvRooij.Testcontainers.IdentityProxy.Tests/IdentityProxyInitializationTests.cs
+++ b/tests/SvRooij.Testcontainers.IdentityProxy.Tests/IdentityProxyInitializationTests.cs
@@ -23,7 +23,7 @@ public class IdentityProxyInitializationTests
     [Test]
     public async Task IdentityProxyContainer_Should_Initialize_Correctly()
     {
-        await _container!.StartAsync(TestContext.Current?.CancellationToken ?? CancellationToken.None);
+        await _container!.StartAsync(TestContext.Current?.Execution.CancellationToken ?? CancellationToken.None);
         var authority = _container.GetAuthority();
         await Assert.That(authority).IsNotNull();
     }

--- a/tests/SvRooij.Testcontainers.IdentityProxy.Tests/SvRooij.Testcontainers.IdentityProxy.Tests.csproj
+++ b/tests/SvRooij.Testcontainers.IdentityProxy.Tests/SvRooij.Testcontainers.IdentityProxy.Tests.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="TUnit" Version="0.70.7" />
+    <PackageReference Include="TUnit" Version="1.3.15" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- Adds OpenAPI/Scalar integration with interactive documentation at /scalar/ endpoint
- Enables multi-targeting for .NET 8.0 and .NET 10.0 in the testcontainers library
- Adds HttpClient injection capability to IdentityProxyContainer for better testability
- Migrates Docker image from nightly preview to stable .NET 10.0 runtime
- Updates certificate loading to use X509CertificateLoader.LoadPkcs12() for modern .NET compatibility
- Updates TUnit test framework