### PR TITLE
Adding support for x5t and x5c in jwks 🧑‍💻

### DIFF
--- a/src/IdentityProxy.Api/Identity/IdentityService.cs
+++ b/src/IdentityProxy.Api/Identity/IdentityService.cs
@@ -71,22 +71,21 @@ internal partial class IdentityService
         using var rsa = certificate.PublicKey.GetRSAPublicKey();
         // Using an RSA Security Key here, instead of a X509SecurityKey, because the support for RSA keys is better on JWT libraries on other platforms.
         var rsaKey = JsonWebKeyConverter.ConvertFromRSASecurityKey(new RsaSecurityKey(rsa));
-        // Apparently the KeyId of an RSA key does not get set by default, bug? This is how the `InternalKeyId` is calculated.
-        var kid = Base64UrlEncoder.Encode(rsaKey.ComputeJwkThumbprint());
-        LogInjectingCertificate(kid);
+        // Use the SHA-1 thumbprint as kid, matching Microsoft's convention (kid == x5t)
+        var x5t = Base64UrlEncoder.Encode(certificate.GetCertHash());
+        LogInjectingCertificate(x5t);
 
         var jwk = new Jwk
         {
-            // Not sure if this is the correct way to get the kid
-            Kid = kid,
+            Kid = x5t,
             KeyType = rsaKey.Kty,
             // rsaKey.Use is not available, so we use "sig" instead
             Usage = "sig",
             NotBefore = new DateTimeOffset(certificate.NotBefore).ToUnixTimeSeconds(),
             Exponent = rsaKey.E,
             Modulus = rsaKey.N,
-            // SHA-1 thumbprint, Base64Url encoded
-            X509Thumbprint = Base64UrlEncoder.Encode(certificate.GetCertHash()),
+            // SHA-1 thumbprint, Base64Url encoded — same value as kid, matching Microsoft's convention
+            X509Thumbprint = x5t,
             // DER-encoded certificate, Base64 encoded (not URL-safe)
             X509CertificateChain = [Convert.ToBase64String(certificate.RawData)],
         };
@@ -115,8 +114,8 @@ internal partial class IdentityService
         // Using an RSA Security Key here, instead of a X509SecurityKey, because the support for RSA keys is better on JWT libraries on other platforms.
         // And because I have not seen a lot of examples with X509SecurityKey or the 'x5t' in the jwks.
         var securityKey = new RsaSecurityKey(rsa);
-        // WTF Microsoft, why is this empty?
-        securityKey.KeyId = Base64UrlEncoder.Encode(securityKey.ComputeJwkThumbprint());
+        // Use the SHA-1 thumbprint as kid, matching Microsoft's convention (kid == x5t)
+        securityKey.KeyId = Base64UrlEncoder.Encode(certificate.GetCertHash());
 
         Dictionary<string, object> claims = new()
         {

--- a/src/IdentityProxy.Api/Identity/IdentityService.cs
+++ b/src/IdentityProxy.Api/Identity/IdentityService.cs
@@ -85,6 +85,10 @@ internal partial class IdentityService
             NotBefore = new DateTimeOffset(certificate.NotBefore).ToUnixTimeSeconds(),
             Exponent = rsaKey.E,
             Modulus = rsaKey.N,
+            // SHA-1 thumbprint, Base64Url encoded
+            X509Thumbprint = Base64UrlEncoder.Encode(certificate.GetCertHash()),
+            // DER-encoded certificate, Base64 encoded (not URL-safe)
+            X509CertificateChain = [Convert.ToBase64String(certificate.RawData)],
         };
 
         // Create new Jwks object with the keys from the externalJwks.Keys and the jwk for the certificate

--- a/src/IdentityProxy.Api/Identity/Models/Jwks.cs
+++ b/src/IdentityProxy.Api/Identity/Models/Jwks.cs
@@ -11,16 +11,20 @@ public class Jwks
 
 public class Jwk
 {
-    [JsonPropertyName("kid")]
-    public string? Kid { get; set; }
-    [JsonPropertyName("nbf")]
-    public long? NotBefore { get; set; }
-    [JsonPropertyName("use")]
-    public string? Usage { get; set; }
     [JsonPropertyName("kty")]
     public string? KeyType { get; set; }
-    [JsonPropertyName("e")]
-    public string? Exponent { get; set; }
+    [JsonPropertyName("use")]
+    public string? Usage { get; set; }
+    [JsonPropertyName("kid")]
+    public string? Kid { get; set; }
+    [JsonPropertyName("x5t")]
+    public string? X509Thumbprint { get; set; }
+    [JsonPropertyName("nbf")]
+    public long? NotBefore { get; set; }
     [JsonPropertyName("n")]
     public string? Modulus { get; set; }
+    [JsonPropertyName("e")]
+    public string? Exponent { get; set; }
+    [JsonPropertyName("x5c")]
+    public string[]? X509CertificateChain { get; set; }
 }

--- a/src/IdentityProxy.Api/Program.cs
+++ b/src/IdentityProxy.Api/Program.cs
@@ -24,7 +24,7 @@ builder.Services.ConfigureHttpJsonOptions(options =>
 
 var app = builder.Build();
 // Add the identity endpoints
-app.MapIdentityEndpoints(externalUrl: app.Configuration.GetValue<string>("EXTERNAL_URL"));
+app.MapIdentityEndpoints(externalUrl: app.Configuration.GetValue<string>("EXTERNAL_URL")?.TrimEnd('/'));
 app.MapOpenApi();
 app.MapScalarApiReference(options =>
 {
@@ -35,4 +35,5 @@ app.MapScalarApiReference(options =>
 });
 
 app.Logger.LogInformation("IdentityProxy will proxy authority: {Authority}", authority);
+app.Logger.LogInformation("Documentation available at: {DocsUrl}", app.Configuration.GetValue<string>("EXTERNAL_URL")?.TrimEnd('/') + "/scalar");
 await app.RunAsync();

--- a/src/IdentityProxy.Api/Program.cs
+++ b/src/IdentityProxy.Api/Program.cs
@@ -24,8 +24,9 @@ builder.Services.ConfigureHttpJsonOptions(options =>
 });
 
 var app = builder.Build();
+var externalUrl = app.Configuration.GetValue<string>("EXTERNAL_URL")?.TrimEnd('/');
 // Add the identity endpoints
-app.MapIdentityEndpoints(externalUrl: app.Configuration.GetValue<string>("EXTERNAL_URL")?.TrimEnd('/'));
+app.MapIdentityEndpoints(externalUrl: externalUrl);
 app.MapOpenApi();
 app.MapScalarApiReference(options =>
 {
@@ -36,5 +37,5 @@ app.MapScalarApiReference(options =>
 });
 
 app.Logger.LogInformation("IdentityProxy will proxy authority: {Authority}", authority);
-app.Logger.LogInformation("Documentation available at: {DocsUrl}", app.Configuration.GetValue<string>("EXTERNAL_URL")?.TrimEnd('/') + "/scalar");
+app.Logger.LogInformation("Documentation available at: {ExternalUrl}/scalar", externalUrl);
 await app.RunAsync();

--- a/src/IdentityProxy.Api/Program.cs
+++ b/src/IdentityProxy.Api/Program.cs
@@ -19,6 +19,7 @@ builder.Services.AddHttpClient<IdentityService>();
 // Json serialization in AOT project
 builder.Services.ConfigureHttpJsonOptions(options =>
 {
+    options.SerializerOptions.DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull;
     options.SerializerOptions.TypeInfoResolverChain.Insert(0, IdentityJsonSerializerContext.Default);
 });
 


### PR DESCRIPTION


<!-- auto-label-commits-start -->

## Commits

- Adding support for x5t and x5c in jwks (ef1b6f7)
- Replace kid with x5t value per Microsoft convention (a209fe1)
- Dont serialize default values in json (02bff47)
- Load external url only once (482a4a7)

<!-- auto-label-commits-end -->